### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,7 @@ sed -i '' 's/Your Name/Your Real Name/' ~/.gitconfig
 ```
 
 Then edit further as needed.
-Note: `.gitconfig` itself is intentionally ignored via `.gitignore` to prevent committing personal identity/signing details. Use the template as a base and keep any private or machine‑specific overrides in an untracked `~/.gitconfig.local` included with:
-
-```ini
-[include]
-   path = ~/.gitconfig.local
-```
+Note: `.gitconfig` is intentionally ignored via `.gitignore` to prevent committing personal identity/signing details. Use the example as a base; maintain your personal `~/.gitconfig` directly (no auxiliary local include file is used by design).
 
 ### .editorconfig
 

--- a/README.md
+++ b/README.md
@@ -91,37 +91,11 @@ sed -i '' 's/Your Name/Your Real Name/' ~/.gitconfig
 ```
 
 Then edit further as needed.
+Note: `.gitconfig` itself is intentionally ignored via `.gitignore` to prevent committing personal identity/signing details. Use the template as a base and keep any private or machine‑specific overrides in an untracked `~/.gitconfig.local` included with:
 
-#### Verifying `.gitconfig` is no longer tracked
-
-Before committing the removal (you should see the staged deletion line):
-
-```sh
-git status --short | grep '^D  \.gitconfig' && echo '.gitconfig staged for deletion'
-```
-
-After committing (should report not tracked):
-
-```sh
-git ls-files --error-unmatch .gitconfig 2>/dev/null || echo '.gitconfig not tracked ✅'
-```
-
-Confirm the deletion exists in the most recent commit diff (after commit):
-
-```sh
-git show --name-status --oneline -1 | grep '^D\s\+\.gitconfig' && echo 'Deletion recorded in last commit'
-```
-
-If you accidentally re-add it:
-
-```sh
-git restore --staged .gitconfig && echo 'Unstaged .gitconfig' && git update-index --assume-unchanged .gitconfig
-```
-
-Or just remove it from the index again:
-
-```sh
-git rm --cached .gitconfig
+```ini
+[include]
+   path = ~/.gitconfig.local
 ```
 
 ### .editorconfig

--- a/install.sh
+++ b/install.sh
@@ -68,8 +68,15 @@ else
     echo "exports.zsh not found. Please check your dotfiles setup."
 fi
 
-# Git config template: copy example if user does not already have one
-if [ ! -f "$HOME/.gitconfig" ] && [ -f "$PWD/.gitconfig.example" ]; then
+# Git config template handling
+# Only create ~/.gitconfig from example if none exists. Never overwrite an existing file.
+if [ -f "$HOME/.gitconfig" ]; then
+    echo "Skipping git config template: ~/.gitconfig already exists (left untouched)."
+elif [ -L "$HOME/.gitconfig" ]; then
+    echo "NOTE: ~/.gitconfig is a symlink; not replacing."
+elif [ -f "$PWD/.gitconfig.example" ]; then
     cp "$PWD/.gitconfig.example" "$HOME/.gitconfig"
-    echo "Created ~/.gitconfig from template (.gitconfig.example). Please edit your name/email."
+    echo "Created ~/.gitconfig from template (.gitconfig.example). Edit your name/email & signing key." 
+else
+    echo "No .gitconfig.example found; skipping git config setup."
 fi


### PR DESCRIPTION
This pull request simplifies and clarifies the handling of the `.gitconfig` file in both the installation script and documentation. The changes ensure that users' personal git configuration files are never overwritten and provide clearer guidance on setup.

**Improvements to `.gitconfig` handling:**

* Updated `install.sh` to avoid overwriting an existing `~/.gitconfig` file or replacing it if it is a symlink; the script now only copies the example config if no config exists, and provides clear messages for each case.
* Revised the `README.md` to clarify that `.gitconfig` is intentionally ignored and should be managed directly by the user, removing the previous detailed verification steps for deletion from version control.