### PR TITLE
feat: dotfiles go profiles

### DIFF
--- a/.config/homebrew/Brewfile.personal
+++ b/.config/homebrew/Brewfile.personal
@@ -1,0 +1,20 @@
+brew "fzf"              # Command-line fuzzy finder
+brew "gh"               # GitHub CLI
+brew "git"              # Git version control
+brew "mas"              # Mac App Store CLI
+brew "starship"         # Cross-shell prompt
+brew "volta"            # Node.js version manager
+
+cask "discord"                  # Chat for communities and teams (personal only)
+cask "firefox-developer-edition" # Firefox Developer Edition browser
+cask "font-fira-code-nerd-font" # Fira Code font with Nerd Font patches
+cask "google-chrome"            # Google Chrome browser
+cask "hiddenbar"                # Menu bar organizer
+cask "imageoptim"               # Image compression tool
+cask "insomnia"                 # API client for REST and GraphQL
+cask "kap"                      # Screen recorder
+cask "microsoft-edge"           # Microsoft Edge browser
+cask "protonvpn"                # VPN client
+cask "rectangle"                # Window manager
+cask "vlc"                      # Media player
+cask "visual-studio-code"       # Code editor

--- a/.config/homebrew/Brewfile.work
+++ b/.config/homebrew/Brewfile.work
@@ -5,7 +5,7 @@ brew "mas"              # Mac App Store CLI
 brew "starship"         # Cross-shell prompt
 brew "volta"            # Node.js version manager
 
-cask "discord"                  # Chat for communities and teams
+# Work profile excludes some personal apps like Discord and ProtonVPN
 cask "firefox-developer-edition" # Firefox Developer Edition browser
 cask "font-fira-code-nerd-font" # Fira Code font with Nerd Font patches
 cask "google-chrome"            # Google Chrome browser
@@ -14,7 +14,6 @@ cask "imageoptim"               # Image compression tool
 cask "insomnia"                 # API client for REST and GraphQL
 cask "kap"                      # Screen recorder
 cask "microsoft-edge"           # Microsoft Edge browser
-cask "protonvpn"                # VPN client
 cask "rectangle"                # Window manager
 cask "vlc"                      # Media player
 cask "visual-studio-code"       # Code editor

--- a/.config/vscode/README.md
+++ b/.config/vscode/README.md
@@ -1,0 +1,12 @@
+# VS Code profile and extensions folder
+
+This folder contains machine-specific VS Code configuration, profiles and extension lists.
+
+Files you can add here:
+
+-   `profiles/` — a folder to store VS Code Profile JSON files
+-   `extensions-personal.txt` — newline-separated list of extensions for personal machines
+-   `extensions-work.txt` — newline-separated list of extensions for work machines
+
+The `install.sh` script does not automatically install VS Code extensions yet, but this
+is a ready place to keep those lists and profile exports.

--- a/.config/vscode/extensions-personal.txt
+++ b/.config/vscode/extensions-personal.txt
@@ -1,0 +1,19 @@
+
+# VS Code extensions for personal machines (merged example + current work list)
+astro-build.astro-vscode
+dbaeumer.vscode-eslint
+esbenp.prettier-vscode
+figma.figma-vscode-extension
+gael-lopes-da-silva.colored
+ms-python.python
+ms-vscode.cpptools
+ms-vscode.powershell
+ms-vscode.vscode-typescript-next
+github.copilot
+github.copilot-chat
+github.github-vscode-theme
+mechatroner.rainbow-csv
+oderwat.indent-rainbow
+streetsidesoftware.code-spell-checker
+unifiedjs.vscode-mdx
+vunguyentuan.vscode-css-variables

--- a/.config/vscode/extensions-work.txt
+++ b/.config/vscode/extensions-work.txt
@@ -1,0 +1,14 @@
+# VS Code extensions for work machines (exported from this machine)
+astro-build.astro-vscode
+dbaeumer.vscode-eslint
+esbenp.prettier-vscode
+figma.figma-vscode-extension
+gael-lopes-da-silva.colored
+github.copilot
+github.copilot-chat
+github.github-vscode-theme
+mechatroner.rainbow-csv
+oderwat.indent-rainbow
+streetsidesoftware.code-spell-checker
+unifiedjs.vscode-mdx
+vunguyentuan.vscode-css-variables

--- a/.config/vscode/import-profile.sh
+++ b/.config/vscode/import-profile.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+# Helper: open a VS Code profile file and print instructions to import it.
+# Usage: ./import-profile.sh template-work.code-profile
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <profile-file>"
+  exit 1
+fi
+PROFILE_FILE="$PWD/profiles/$1"
+if [ ! -f "$PROFILE_FILE" ]; then
+  echo "Profile file not found: $PROFILE_FILE"
+  exit 2
+fi
+
+if command -v code >/dev/null 2>&1; then
+  echo "Opening profile file in VS Code: $PROFILE_FILE"
+  code "$PROFILE_FILE"
+  echo "In VS Code: Command Palette -> 'Profiles: Import Profile From File...' and choose the opened file."
+else
+  echo "Please open the file in VS Code and import it via Command Palette -> 'Profiles: Import Profile From File...'"
+fi

--- a/.config/vscode/profiles/template-personal.code-profile
+++ b/.config/vscode/profiles/template-personal.code-profile
@@ -1,0 +1,13 @@
+{
+    "name": "Personal",
+    "settings": {
+        "workbench.colorTheme": "Default Light+",
+        "editor.formatOnSave": false
+    },
+    "extensions": {
+        "recommendations": [
+            "esbenp.prettier-vscode",
+            "mechatroner.rainbow-csv"
+        ]
+    }
+}

--- a/.config/vscode/profiles/template-work.code-profile
+++ b/.config/vscode/profiles/template-work.code-profile
@@ -1,0 +1,13 @@
+{
+    "name": "Work",
+    "settings": {
+        "workbench.colorTheme": "Default Dark+",
+        "editor.formatOnSave": true
+    },
+    "extensions": {
+        "recommendations": [
+            "dbaeumer.vscode-eslint",
+            "esbenp.prettier-vscode"
+        ]
+    }
+}

--- a/README.md
+++ b/README.md
@@ -25,14 +25,61 @@ A comprehensive, well-documented set of configuration files and scripts for sett
     cd ~/Developer/dotfiles
     ```
 2. **Install Homebrew packages and casks:**
+   There are two Brewfiles included so you can keep personal and work machines separate. They live under
+   `.config/homebrew/` in the repo:
+
+    - `.config/homebrew/Brewfile.personal` — personal laptop defaults (includes apps like Discord, ProtonVPN)
+    - `.config/homebrew/Brewfile.work` — work laptop defaults (excludes some personal apps)
+
+    You can run a bundle directly, for example:
+
     ```sh
-    brew bundle --file=Brewfile
+    brew bundle --file=.config/homebrew/Brewfile.personal
+    # or
+    brew bundle --file=.config/homebrew/Brewfile.work
     ```
-3. **Symlink dotfiles to your home directory:**
+
+3. **Symlink dotfiles to your home directory and (optionally) install apps:**
+
     ```sh
     ./install.sh
     ```
+
+    `install.sh` can now be driven either interactively or via flags/env vars. Usage examples:
+
+    - Interactive (prompts for profile and whether to run brew bundle):
+
+    ```sh
+    ./install.sh
+    ```
+
+    - Non-interactive using env var to choose profile (will skip brew bundle unless `--auto-brew` is used):
+
+    ```sh
+    DOTFILES_PROFILE=work ./install.sh
+    ```
+
+    - Non-interactive and auto-run brew bundle for chosen profile:
+
+    ```sh
+    ./install.sh --profile=work --auto-brew
+    ```
+
+    Flags supported:
+
+    - `--profile=personal|work` — select profile explicitly (overrides `DOTFILES_PROFILE`)
+    - `--auto-brew` — automatically run `brew bundle --file=.config/homebrew/Brewfile.<profile>` without prompting
+    - `--no-brew` — explicitly skip brew bundle
+    - `--install-vscode-extensions` — install VS Code extensions listed in `.config/vscode/extensions-<profile>.txt`
+    - `--yes` — non-interactive shortcut that implies `--auto-brew` and `--install-vscode-extensions`
+
+    If a matching Brewfile isn't present under `.config/homebrew/`, the script will skip the bundle step and continue with symlinking.
+
+    VS Code: there's a `.config/vscode/` folder for keeping VS Code profiles and per-profile extension lists. Use `--install-vscode-extensions` to have `install.sh` automatically install extension lists.
+
+    A small helper is provided at `.config/vscode/import-profile.sh` to open a template `.code-profile` file in VS Code and remind you how to import it via the Command Palette. Importing profiles into VS Code remains a manual UI action.
     This will create symbolic links for:
+
     - `.config`
     - `.editorconfig`
     - `.gitignore`


### PR DESCRIPTION
This pull request introduces support for per-profile (personal vs. work) configuration and installation in the dotfiles setup, with improved automation and documentation. The main enhancements are the addition of separate Homebrew and VS Code configuration files for each profile, new command-line options for the `install.sh` script, and documentation updates to guide users through the new workflow.

**Profile-based configuration and automation:**

* Added support for personal and work profiles in `install.sh`, allowing users to select a profile via CLI flags or environment variable, and to control Homebrew and VS Code extension installation with new flags (`--profile`, `--auto-brew`, `--install-vscode-extensions`, `--yes`, `--no-brew`). [[1]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR5-R6) [[2]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR23-R93) [[3]](diffhunk://#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44fR156-R172)
* Homebrew package lists are now split into `.config/homebrew/Brewfile.personal` and `.config/homebrew/Brewfile.work`, enabling different setups for personal and work machines. [[1]](diffhunk://#diff-c109be135e5975a86963917ae1abfbdcbc44614abb858899145b9bf83d4cae3dL8-R8) [[2]](diffhunk://#diff-8a32d9c73f694546e15a7461da62216c4aca72029b971aa961dfaa1602edbbe2R1-R19)
* Added per-profile VS Code extension lists (`extensions-personal.txt`, `extensions-work.txt`) and profile templates (`template-personal.code-profile`, `template-work.code-profile`) under `.config/vscode/`. [[1]](diffhunk://#diff-91880a0494022102c451aa2d6b1eec3b979e66ce9bdad0dd6122030c07f6d3b4R1-R19) [[2]](diffhunk://#diff-cf2a4f116ed92c2a3a540111209fedf3ba816f16cbc794efed2f4fb968f76748R1-R14) [[3]](diffhunk://#diff-35fdb0a7a635e02c30d9bb6f2d40bc28b1cfce56464ea21f3c909deff01ccc19R1-R13) [[4]](diffhunk://#diff-40e4042cf9ed98012509434a87a46f5e42cb34b281c4a79fa40644c419d5db6aR1-R13)
* The `install.sh` script can now automatically install VS Code extensions for the selected profile.

**Documentation and helper scripts:**

* Updated `README.md` with clear instructions for using per-profile Homebrew and VS Code configuration, including new usage examples for `install.sh` and details on the new flags and workflow.
* Added `.config/vscode/README.md` to explain the structure and usage of VS Code profiles and extension lists.
* Added `.config/vscode/import-profile.sh` as a helper script to guide users in importing VS Code profiles manually.