### PR TITLE
feat: more robust fzf sourcing

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -24,7 +24,9 @@ source $ZSH/oh-my-zsh.sh
 eval "$(starship init zsh)"
 
 # fzf integration (key bindings + completion)
-[ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
+[ -f ~/.fzf.zsh ] \
+	&& source ~/.fzf.zsh \
+	|| { [ -x "$(command -v fzf 2>/dev/null)" ] && source <(fzf --zsh); }
 
 # Environment exports (PATH, toolchain managers, etc.)
 [ -f "$ZSH_CUSTOM/exports.zsh" ] && source "$ZSH_CUSTOM/exports.zsh"


### PR DESCRIPTION
This pull request updates the `.zshrc` configuration to improve the robustness of the fzf integration. Now, if the `.fzf.zsh` file is not present, the configuration will fall back to sourcing the fzf shell integration directly if the `fzf` command is available.

Shell integration improvements:

* Enhanced fzf integration logic in `.zshrc` to source shell integration from the `fzf` command if `.fzf.zsh` is missing, ensuring fzf features are available regardless of installation method.